### PR TITLE
corrigindo bug que quebra o sistema quando vai buscar algum arquivo p…

### DIFF
--- a/assets/detector.py
+++ b/assets/detector.py
@@ -111,7 +111,8 @@ class Detector:
 						source.content[i].lstrip().find("for ") == 0 )):
 
 						if (len(self.how_many_assertions(source, method)) > 0 or self.prefixed_with_test(method)):
-							occ.append(i+1)
+							if(self.contains_subtest(source,i) == False):
+								occ.append(i+1)
 				
 				if (len(occ) > 0):
 					for x in range(len(occ)):
@@ -120,6 +121,13 @@ class Detector:
 						lista.clear()
 					occ.clear()
 
+
+	def contains_subtest(self, source, i):
+		size = len(source.content)
+		if(size > i + 1):
+			return (source.content[i+1].lstrip().find("subTest") != -1)
+		else:
+			return False
 
 	def redundant_print(self, source, methods):
 		lista,occ = [],[]

--- a/main.py
+++ b/main.py
@@ -176,7 +176,7 @@ def search_test_file(tempdir):
 	for dirName, subdirList, fileList in os.walk(tempdir):
 		if( not is_hidden_directory(dirName) ):
 			for x in fileList:
-				if ( x.find( '.py' )!=-1 and x.find( 'main.py' )==-1):
+				if ( x.endswith( '.py' ) and x.find( 'main.py' )==-1):
 					if (is_test_file(x,dirName)):
 						number_of_files += 1
 						nomes.append(x)


### PR DESCRIPTION
quando rodamos algum projeto python ele gera arquivos 'pyc', quando colocamos o TEMP para buscar arquivos de testes nesse projeto ele apresenta um erro de leitura, já que tenta ler um binário para verificar se é um arquivo de teste, a correção que coloquei é simples, ao invés de procurar a sequencia de caractere '.py' em qualquer parte da string, coloquei para ter que terminar exatamente assim a string.